### PR TITLE
Fix LauncherItem animating when first created

### DIFF
--- a/src/qml/pages/AppLauncher/LauncherItem.qml
+++ b/src/qml/pages/AppLauncher/LauncherItem.qml
@@ -62,8 +62,10 @@ MouseArea {
                 }
             }
         }
-        NumberAnimation on scale {
+        NumberAnimation {
             id: launchAnimationStage1
+            target: parent
+            property: "scale"
             from: 1
             to: 0.6
             duration: 700
@@ -74,8 +76,10 @@ MouseArea {
                     iconImage.scale = 1.0;
             }
         }
-        NumberAnimation on scale {
+        NumberAnimation {
             id: launchAnimationStage2
+            target: parent
+            property: "scale"
             from: 0.6
             to: 1
             duration: 700


### PR DESCRIPTION
QML Animations using the 'Animation on x' syntax have 'running' by
default, which caused these to scale up after being created. That
would cause CPU waste on rotation and scrolling, and was visible in
a few situations.

Test: Scroll to the top in portrait, switch to landscape, scroll to
the bottom, switch to portrait, and quickly scroll down. The bottom
items will be scaling up as they come into view.
