### PR TITLE
Allow for moving launcher icons

### DIFF
--- a/src/qml/AppLauncher.qml
+++ b/src/qml/AppLauncher.qml
@@ -35,6 +35,7 @@ GridView {
     cellHeight: cellWidth + 30
     width: Math.floor(parent.width / cellWidth) * cellWidth
     cacheBuffer: gridview.contentHeight
+    property Item reorderItem
 
     // just for margin purposes
     header: Item {
@@ -45,7 +46,7 @@ GridView {
         height: 20
     }
 
-    model: LauncherModel { }
+    model: LauncherModel { id: launcherModel }
 
     delegate: LauncherItemDelegate {
         id: launcherItem
@@ -53,6 +54,5 @@ GridView {
         height: gridview.cellHeight
         source: model.object.iconId == "" ? ":/images/icons/apps.png" : (model.object.iconId.indexOf("/") == 0 ? "file://" : "image://theme/") + model.object.iconId
         iconCaption: model.object.title
-        onClicked: model.object.launchApplication();
     }
 }

--- a/src/qml/LauncherItemDelegate.qml
+++ b/src/qml/LauncherItemDelegate.qml
@@ -19,60 +19,166 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-// Copyright (c) 2011, Tom Swindell <t.swindell@rubyx.co.uk>
+// Copyright (c) 2013, Jolla Ltd <robin.burchell@jollamobile.com>
 // Copyright (c) 2012, Timur Kristóf <venemo@fedoraproject.org>
+// Copyright (c) 2011, Tom Swindell <t.swindell@rubyx.co.uk>
 
 import QtQuick 1.1
 import com.nokia.meego 1.2
 
-MouseArea {
-    id: launcherItem
+Item {
+    id: wrapper
     property alias source: iconImage.source
     property alias iconCaption: iconText.text
+    property bool reordering
+    property int newIndex: -1
+    property real oldY
 
-    // Application icon for the launcher
-    Image {
-        id: iconImage
-        anchors {
-            horizontalCenter: parent.horizontalCenter
-            top: parent.top
-            topMargin: 8
-        }
-        width: 80
-        height: width
-        asynchronous: true
-        opacity: model.object.isLaunching || launcherItem.pressed ? 0.6 : 1.0
-        onStatusChanged: {
-            if (status === Image.Error) {
-                console.log("Error loading an app icon, falling back to default.");
-                iconImage.source = ":/images/icons/apps.png";
-            }
-        }
+    onXChanged: moveTimer.start()
+    onYChanged: moveTimer.start()
 
-        BusyIndicator {
-            anchors.centerIn: parent
-            opacity: model.object.isLaunching ? 1.0 : 0.0
-            running: model.object.isLaunching
-            platformStyle: BusyIndicatorStyle {
-                size: "large"
+    Timer {
+        id: moveTimer
+        interval: 1
+        onTriggered: moveIcon()
+    }
+
+    function moveIcon() {
+        if (!reordering) {
+            if (!slideMoveAnim.running) {
+                slideMoveAnim.start()
             }
         }
     }
 
-    // Caption for the icon
-    Text {
-        id: iconText
-        // elide only works if an explicit width is set
-        width: parent.width
-        elide: Text.ElideRight
-        horizontalAlignment: Text.AlignHCenter
-        font.pixelSize: 20
-        color: 'white'
-        anchors {
-            left: parent.left
-            right: parent.right
-            top: iconImage.bottom
-            topMargin: 5
+    // Application icon for the launcher
+    MouseArea {
+        id: launcherItem
+        width: wrapper.width
+        height: wrapper.height
+        parent: gridview.contentItem
+        scale: reordering ? 1.3 : 1
+        transformOrigin: Item.Center
+        onXChanged: moved()
+        onYChanged: moved()
+
+        onClicked: {
+            // TODO: disallow if close mode enabled
+            model.object.launchApplication()
+        }
+
+        onPressAndHold: {
+            reparent(gridview)
+            reorderItem = launcherItem
+            drag.target = launcherItem
+            z = 1000
+            reordering = true
+
+            // don't allow dragging an icon out of pages with a horizontal flick
+            pager.interactive = false
+        }
+
+        onReleased: {
+            if (reordering) {
+                reordering = false
+                reorderTimer.stop()
+                drag.target = null
+                reorderItem = null
+                reparent(gridview.contentItem)
+                slideMoveAnim.start()
+                pager.interactive = true
+            }
+        }
+
+        function reparent(newParent) {
+            var newPos = mapToItem(newParent, 0, 0)
+            parent = newParent
+            x = newPos.x - width/2 * (1-scale)
+            y = newPos.y - height/2 * (1-scale)
+        }
+
+        function moved() {
+            if (reordering) {
+                var gridViewPos = gridview.contentItem.mapFromItem(launcherItem, width/2, height/2)
+                var idx = gridview.indexAt(gridViewPos.x, gridViewPos.y)
+                if (newIndex !== idx) {
+                    reorderTimer.restart()
+                    newIndex = idx
+                }
+/*
+                var globalY = desktop.mapFromItem(launcherItem, 0, 0).y
+                if (globalY < 70) {
+                    pageChangeTimer.start()
+                } else {
+                    pageChangeTimer.stop()
+                }
+*/
+            }
+        }
+
+        Timer {
+            id: reorderTimer
+            interval: 100
+            onTriggered: {
+                if (newIndex != -1 && newIndex !== index) {
+                    launcherModel.move(index, newIndex)
+                }
+                newIndex = -1
+            }
+        }
+
+        Behavior on scale {
+            NumberAnimation { easing.type: Easing.InOutQuad; duration: 150 }
+        }
+
+        ParallelAnimation {
+            id: slideMoveAnim
+            NumberAnimation { target: launcherItem; property: "x"; to: wrapper.x; duration: 130; easing.type: Easing.OutQuint }
+            NumberAnimation { target: launcherItem; property: "y"; to: wrapper.y; duration: 130; easing.type: Easing.OutQuint }
+        }
+
+        Image {
+            id: iconImage
+            anchors {
+                horizontalCenter: parent.horizontalCenter
+                top: parent.top
+                topMargin: 8
+            }
+            width: 80
+            height: width
+            asynchronous: true
+            onStatusChanged: {
+                if (status === Image.Error) {
+                    console.log("Error loading an app icon, falling back to default.");
+                    iconImage.source = ":/images/icons/apps.png";
+                }
+            }
+
+            BusyIndicator {
+                anchors.centerIn: parent
+                opacity: model.object.isLaunching ? 1.0 : 0.0
+                running: model.object.isLaunching
+                platformStyle: BusyIndicatorStyle {
+                    size: "large"
+                }
+            }
+        }
+
+        // Caption for the icon
+        Text {
+            id: iconText
+            // elide only works if an explicit width is set
+            width: parent.width
+            elide: Text.ElideRight
+            horizontalAlignment: Text.AlignHCenter
+            font.pixelSize: 20
+            color: 'white'
+            anchors {
+                left: parent.left
+                right: parent.right
+                top: iconImage.bottom
+                topMargin: 5
+            }
         }
     }
 }

--- a/src/qml/Pager.qml
+++ b/src/qml/Pager.qml
@@ -24,7 +24,7 @@
 import QtQuick 1.2
 
 PathView {
-    id: view
+    id: pager
     highlightRangeMode: PathView.StrictlyEnforceRange
     preferredHighlightBegin: 0.5
     preferredHighlightEnd: 0.5


### PR DESCRIPTION
Simple enough. Tap and hold, drag to move.

Not implemented: an animation on contentY when the icon approaches the vertical borders of the grid.
