### PR TITLE
Fix lockscreen being partially shown after orientation change

### DIFF
--- a/src/qml/Lockscreen.qml
+++ b/src/qml/Lockscreen.qml
@@ -11,6 +11,15 @@ Image {
      **/
     property real openingState: y / -height
     visible: openingState < 1
+    onHeightChanged: {
+        if (mouseArea.fingerDown)
+            return // we'll fix this up on touch release via the animations
+
+        if (snapOpenAnimation.running)
+            snapOpenAnimation.to = -height
+        else if (!snapClosedAnimation.running && !LipstickSettings.lockscreenVisible)
+            y = -height
+    }
 
     function snapPosition() {
         if (LipstickSettings.lockscreenVisible) {
@@ -71,7 +80,7 @@ Image {
             parent.y = parent.y - delta
         }
 
-        onReleased: {
+        function snapBack() {
             fingerDown = false
             if (!LipstickSettings.lockscreenVisible || Math.abs(parent.y) > parent.height / 3) {
                 LipstickSettings.lockscreenVisible = false
@@ -81,6 +90,9 @@ Image {
 
             lockScreen.snapPosition()
         }
+
+        onCanceled: snapBack()
+        onReleased: snapBack()
     }
 
     LockscreenClock {


### PR DESCRIPTION
...en the unlock screen partial lockscreen is shown

onReleased is not delivered in all circumstances, so hook onCanceled too. Also
make sure to reset the y position of the lockscreen element when appropriate.
